### PR TITLE
Fix for channel detection on subchannels ending in zero.

### DIFF
--- a/LocastService.py
+++ b/LocastService.py
@@ -209,7 +209,12 @@ class LocastService:
             # whether the first char is a number (checking for result like "2.1 CBS")
             try:
                 # if number, get the channel and name -- we're done!
-                stationsRes[index]['channel'] = float(locast_station['callSign'].split()[0])
+                # Check if the the callsign has a float (x.x) value. Save as a 
+                # string though, to preserve any trailing 0s as on reported
+                # on https://github.com/tgorgdotcom/locast2plex/issues/42
+
+                assert(float(locast_station['callSign'].split()[0]))
+                stationsRes[index]['channel'] = locast_station['callSign'].split()[0]
                 
             except ValueError:
                 # result like "WDPN" or "CBS" in the callsign field, or the callsign in the name field


### PR DESCRIPTION
Slight change to fix channel detection for subchannels that end in a 0, such as 3.10. Float drops the trailing zero, so change to test for a float value, but save as a str. Just using an assert since we're throwing the float result away. Should help address issue #42