### PR TITLE
Refactoring geolocation to mirror Locast methods.

### DIFF
--- a/main.py
+++ b/main.py
@@ -273,8 +273,7 @@ if __name__ == '__main__':
     config = {
         'locast_username': None,
         'locast_password': None,
-        'override_latitude': None,
-        'override_longitude': None,
+        'override_zipcode': None,
         'bytes_per_read': '1152000',
         'plex_accessible_ip': '0.0.0.0',
         'plex_accessible_port': '6077',
@@ -311,8 +310,7 @@ if __name__ == '__main__':
     HOST_PORT = config["plex_accessible_port"]
     HOST_ADDY = config["plex_accessible_ip"]
     BYTES_PER_READ = int(config["bytes_per_read"])
-    OVERRIDE_LATITUDE = config["override_latitude"]
-    OVERRIDE_LONGITUDE = config["override_longitude"]
+    OVERRIDE_ZIPCODE = config["override_zipcode"]
     REPORTING_MODEL = config["reporting_model"]
     REPORTING_FIRMWARE_NAME = config["reporting_firmware_name"]
     REPORTING_FIRMWARE_VER = config["reporting_firmware_ver"]
@@ -338,15 +336,7 @@ if __name__ == '__main__':
 
     ffmpeg_proc = None
 
-    mock_location = None
-    
-    if (not OVERRIDE_LATITUDE is None) and (not OVERRIDE_LONGITUDE is None):
-        mock_location = {
-            "latitude": OVERRIDE_LATITUDE,
-            "longitude": OVERRIDE_LONGITUDE
-        }
-
-    locast = LocastService.LocastService("./", mock_location)
+    locast = LocastService.LocastService("./", OVERRIDE_ZIPCODE)
     station_list = None
 
     

--- a/main.py
+++ b/main.py
@@ -273,6 +273,8 @@ if __name__ == '__main__':
     config = {
         'locast_username': None,
         'locast_password': None,
+        'override_latitude': None,
+        'override_longitude': None,
         'override_zipcode': None,
         'bytes_per_read': '1152000',
         'plex_accessible_ip': '0.0.0.0',
@@ -310,6 +312,8 @@ if __name__ == '__main__':
     HOST_PORT = config["plex_accessible_port"]
     HOST_ADDY = config["plex_accessible_ip"]
     BYTES_PER_READ = int(config["bytes_per_read"])
+    OVERRIDE_LATITUDE = config["override_latitude"]
+    OVERRIDE_LONGITUDE = config["override_longitude"]
     OVERRIDE_ZIPCODE = config["override_zipcode"]
     REPORTING_MODEL = config["reporting_model"]
     REPORTING_FIRMWARE_NAME = config["reporting_firmware_name"]
@@ -335,8 +339,16 @@ if __name__ == '__main__':
 
 
     ffmpeg_proc = None
+    
+    if (OVERRIDE_LATITUDE is not None) and (OVERRIDE_LONGITUDE is not None):
+        mock_location = {
+            "latitude": OVERRIDE_LATITUDE,
+            "longitude": OVERRIDE_LONGITUDE
+        }
+    else:
+        mock_location = None
 
-    locast = LocastService.LocastService("./", OVERRIDE_ZIPCODE)
+    locast = LocastService.LocastService("./", mock_location, OVERRIDE_ZIPCODE)
     station_list = None
 
     


### PR DESCRIPTION
Throwing this out as a proposal to update how the geolocation is performed (after geojs.io suddenly started placing me on the other side of the country by IP, ha). I poked around a bit at how locast.org does geolocation when not available via browser, and this is about as close as I could get. It transitions away from using a manual lat\lon to override an incorrect location, and uses zipcode instead. Also adds in a check via the 'active' value returned from the Locast API, to abort and provide a user friendly error if Locast reports service isn't available in the area. 

Changes:
- Update geolocation methods to try and mirror how locast.org/dma operates.
- Instead of overridding via lat\long, resolve location via more user friendly zipcode. 
- Also allows for a check if Locast has active service in the area and provides a more descriptive error if not.
- Refactored the exception logic for calling urls into a decorator to allow the removal of some duplicate code blocks. 
- Give donation expiration in human readable format instead of epoch.