### PR TITLE
Change base URL to use the HTTP Host header.

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,10 @@ class PlexHttpHandler(BaseHTTPRequestHandler):
     bytes_per_read = 1024000
 
     def do_GET(self):
-        base_url = self.host_address + ':' + self.host_port
+        # Build our base URL on the 'Host' value the client contacted us with.
+        # If missing (oolllddd HTTP1.0 clients), fallback to manually specified.
+        fallback_base = self.host_address + ':' + self.host_port
+        base_url = self.headers.get('Host', fallback_base)
 
         # paths and logic mostly pulled from telly:routes.go: https://github.com/tellytv/telly
         if (self.path == '/') or (self.path == '/device.xml'):


### PR DESCRIPTION
Use the HTTP 'Host' header when available, to make sure the lineup is generated on whatever hostname or IP the client contacted the server on. This should hopefully resolve\negate some of the confusion around setting addresses in configs. Been using this config in my local build for a while without issue; it's similar to the proposed method in #92, just adds a safety net fallback for clients that fail to include the HTTP Host header (old HTTP1.0 clients, or just straight non-compliant clients). 