### PR TITLE
Modularizing client_id

### DIFF
--- a/config_example.ini
+++ b/config_example.ini
@@ -3,6 +3,7 @@
 plex_accessible_ip = 0.0.0.0
 locast_username=username@example.com
 locast_password=1234567
+locast_clientid=api_client_id_here
 
 #disable_ssdp = False
 #plex_accessible_port = 6077

--- a/lib/locast_service.py
+++ b/lib/locast_service.py
@@ -33,7 +33,7 @@ class LocastService:
 
 
     @handle_url_except
-    def login(self, username, password):
+    def login(self, username, password, clientid):
 
         # check environment vars
         if (username is None):
@@ -44,7 +44,11 @@ class LocastService:
             print("Password not specified in config.ini.  Exiting...")
             return False
 
-        # login
+        if (clientid is None):
+            print("ClientID Token not specified in config.ini.  Exiting...")
+            return False
+
+		# login
         print("Logging into Locast using username " + username + "...")
 
         # https://api.locastnet.org/api/user/login
@@ -52,7 +56,7 @@ class LocastService:
         # {"username":"thomas_vg1@hotmail.com","password":"xxxxxxxx"}
 
 
-        loginReq = urllib.request.Request('https://api.locastnet.org/api/user/login?client_id=9qXBrVzpTjUZmVGsZRnnWQ-7GvGeJ48QWtV9v%2Bbsen4%3D',
+        loginReq = urllib.request.Request('https://api.locastnet.org/api/user/login?client_id=' + clientid,
                                           ('{"username":"' + username + '","password":"' + password + '"}').encode("utf-8"),
                                           {'Content-Type': 'application/json', 'User-agent': self.DEFAULT_USER_AGENT})
 

--- a/lib/locast_service.py
+++ b/lib/locast_service.py
@@ -48,7 +48,7 @@ class LocastService:
             print("ClientID Token not specified in config.ini.  Exiting...")
             return False
 
-		# login
+	# login
         print("Logging into Locast using username " + username + "...")
 
         # https://api.locastnet.org/api/user/login

--- a/lib/user_config.py
+++ b/lib/user_config.py
@@ -26,6 +26,7 @@ class UserConfig():
             "cache_dir": None,
             "locast_username": None,
             "locast_password": None,
+            "locast_clientid": None,
             'disable_ssdp': False,
             'epg_update_frequency': 43200, # 12 hours
             'epg_update_days': 7,


### PR DESCRIPTION
Making the client_id  for the API call a variable pulled from the config file, to avoid needing to modify the connection string directly in the code. Just makes things a little easier and cleaner. 